### PR TITLE
Rehashify WebAssembly/binaryen#3012

### DIFF
--- a/src/support/hash.h
+++ b/src/support/hash.h
@@ -45,11 +45,6 @@ inline uint64_t rehash(uint64_t x, uint64_t y) {
   return rehash(ret, HashType(y >> 32));
 }
 
-template<typename T> inline void hash_combine(std::size_t& s, const T& v) {
-  // see boost/container_hash/hash.hpp
-  s ^= std::hash<T>{}(v) + 0x9e3779b9 + (s << 6) + (s >> 2);
-}
-
 } // namespace wasm
 
 #endif // wasm_support_hash_h

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -30,7 +30,7 @@ namespace std {
 template<> class hash<vector<wasm::Type>> {
 public:
   size_t operator()(const vector<wasm::Type>& types) const {
-    auto res = hash<size_t>{}(types.size());
+    uint64_t res = wasm::rehash(0, uint32_t(types.size()));
     for (auto t : types) {
       res = wasm::rehash(res, t.getID());
     }
@@ -39,7 +39,7 @@ public:
 };
 
 size_t hash<wasm::Type>::operator()(const wasm::Type& type) const {
-  return wasm::rehash(uint64_t(0), type.getID());
+  return hash<uint64_t>{}(type.getID());
 }
 
 size_t hash<wasm::Signature>::operator()(const wasm::Signature& sig) const {


### PR DESCRIPTION
This is a standalone PR for using `wasm::rehash` instead of the new `wasm::hash_combine` in WebAssembly/binaryen#3012 that I'd like to use to explain the concerns I have with this implementation.